### PR TITLE
HOTFIX : Remove dependency on google_anlytics

### DIFF
--- a/doghouse_standard.info.yml
+++ b/doghouse_standard.info.yml
@@ -52,7 +52,6 @@ dependencies:
   - ds
   - ds_extras
   - google_tag
-  - google_analytics
   - metatag
   - config_ignore
   - config_readonly


### PR DESCRIPTION
This will help Google Analytics to remove from many sites.